### PR TITLE
Feat: Mutliple telegram users

### DIFF
--- a/etc/data.yaml
+++ b/etc/data.yaml
@@ -1,2 +1,2 @@
 # rpi-security data file. Used to save some persistent config or data
-telegram_chat_id:
+telegram_chat_ids:

--- a/etc/rpi-security.conf
+++ b/etc/rpi-security.conf
@@ -8,6 +8,9 @@ telegram_bot_token=999999999:xxxxxxx-zzzzzzzzzzzzzzzzz
 # The wireless interface in monitor mode
 network_interface=mon0
 
+# The number of people allowed to chat with Telegram bot
+telegram_users_number=1
+
 # Debug mode. Setting this to true will send more verbose logging to syslog
 debug_mode=false
 

--- a/rpisec/threads/telegram_bot.py
+++ b/rpisec/threads/telegram_bot.py
@@ -16,15 +16,19 @@ def telegram_bot(rpis, camera):
     This function runs the telegram bot that responds to commands like /enable, /disable or /status.
     """
     def save_chat_id(bot, update):
-        if 'telegram_chat_id' not in rpis.saved_data or rpis.saved_data['telegram_chat_id'] is None:
+        if 'telegram_chat_ids' not in rpis.saved_data or rpis.saved_data['telegram_chat_ids'] is None:
             rpis.save_telegram_chat_id(update.message.chat_id)
             logger.debug('Set Telegram chat_id {0}'.format(update.message.chat_id))
+        else:
+            if len(rpis.saved_data['telegram_chat_ids']) < rpis.telegram_users_number:
+                rpis.save_telegram_chat_id(update.message.chat_id)
+                logger.debug('Set Telegram chat_id {0}'.format(update.message.chat_id))
 
     def debug(bot, update):
         logger.debug('Received Telegram bot message: {0}'.format(update.message.text))
 
     def check_chat_id(update):
-        if 'telegram_chat_id' in rpis.saved_data and update.message.chat_id != rpis.saved_data['telegram_chat_id']:
+        if 'telegram_chat_ids' in rpis.saved_data and update.message.chat_id not in rpis.saved_data['telegram_chat_ids']:
             logger.debug('Ignoring Telegam update with filtered chat id {0}: {1}'.format(update.message.chat_id, update.message.text))
             return False
         else:


### PR DESCRIPTION
I worked on a feature that allows to have more than 1 telegram user (chat_id).
 - How it works: There is a parameter `telegram_users_number` (default = 1) that allows to customize how many chats will be allowed between the bot and telegram users.

 - Use case: We are 2 in our appartment, we wanted to be both allowed to chat with telegram and receive alerts when motion is detected. I set `telegram_users_number=2` in the config file, we both sent a message to the bot, and now we both receive the notifications.

Tests: I tried multiple notifications, we both received it, we tried with a third people talking to our bot and he didn't received any message

Note: This is my first pull request on this project but i'd like to participate (with motion detection sensibility for example #27 ), so don't hesitate to tell me if i don't respect your code standards ! :)