### PR TITLE
use systemd env file instead of hard-coding network interface device names

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # To do
 
 - Automatically clean up old photos
-- Hard coded `mon0` interface name in `etc/rpi-security.service`
 - Tidy up comments
 - Fig syslog formatting `Dec 22 10:40:02 raspberrypi monitor_alarm_state.py:...` should include service name

--- a/etc/rpi-security-environment
+++ b/etc/rpi-security-environment
@@ -1,0 +1,2 @@
+RPI_SEC_WLAN_ITFC=wlan1
+RPI_SEC_MON=mon0

--- a/etc/rpi-security.service
+++ b/etc/rpi-security.service
@@ -6,11 +6,12 @@ After=multi-user.target
 Type=idle
 StandardOutput=null
 TimeoutStartSec=15
-ExecStartPre=/sbin/iw phy phy0 interface add mon0 type monitor
-ExecStartPre=/sbin/ifconfig mon0 up
+EnvironmentFile=/etc/rpi-security-environment
+ExecStartPre=/sbin/iw dev ${RPI_SEC_WLAN_ITFC} interface add ${RPI_SEC_MON} type monitor
+ExecStartPre=/sbin/ip link set ${RPI_SEC_MON} up
 ExecStart=/usr/local/bin/rpi-security.py
 ExecStop=/usr/bin/pkill rpi-security.py
-ExecStopPost=/sbin/iw dev mon0 del
+ExecStopPost=/sbin/iw dev ${RPI_SEC_MON} del
 
 [Install]
 WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     scripts = ['bin/rpi-security.py'],
     data_files = [
         ('/lib/systemd/system', ['etc/rpi-security.service']),
-        ('/etc', ['etc/rpi-security.conf']),
+        ('/etc', ['etc/rpi-security.conf', 'etc/rpi-security-environment']),
         ('/var/lib/rpi-security', ['etc/data.yaml'])
     ],
     install_requires = [


### PR DESCRIPTION
this commit creates an environment file that exports variables for the
rpi-security service.

It also addresses an issue I faced when first getting this thing running
on my raspberry pi. The interface name is much more predictable than
`phy0` or `phy1`, especially since I wanted to have the embedded wifi
device accessible, and I found this to work consistently across reboots

I'm using `Ralink Technology, Corp. RT5370 Wireless Adapter`